### PR TITLE
record linkage performance testing docker compose

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,8 @@
 .env
+
+# Vim settings
+.exrc
+_exrc
+.vimrc
+_vimrc
+.nvimrc

--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,38 @@
+# Byte-compiled / optimized / DLL files
+__pycache__/
+*.py[cod]
+*$py.class
+
+# Installer logs
+pip-log.txt
+pip-delete-this-directory.txt
+
+# Unit test / coverage reports
+htmlcov/
+.tox/
+.coverage
+.coverage.*
+.cache
+nosetests.xml
+coverage.xml
+*.cover
+*.py,cover
+.hypothesis/
+
+# Jupyter Notebook
+.ipynb_checkpoints
+
+# pipenv
+.Pipfile.lock
+
+# Environments
 .env
+.venv
+env/
+venv/
+ENV/
+env.bak/
+venv.bak/
 
 # Vim settings
 .exrc

--- a/dedupe/record_linkage_testing/Dockerfile.api
+++ b/dedupe/record_linkage_testing/Dockerfile.api
@@ -1,5 +1,8 @@
 ARG VERSION=v1.2.11
-FROM ghcr.io/cdcgov/phdi/record-linkage:${VERSION}
+# The record linkage image is not specifically built for the arm64 architecture,
+# so we need to explicitly state the amd64 architecture here so users running
+# Docker on Apple Silicon know to build the image for the correct architecture.
+FROM --platform=linux/amd64 ghcr.io/cdcgov/phdi/record-linkage:${VERSION}
 
 RUN apt-get update && apt-get install -y curl
 

--- a/dedupe/record_linkage_testing/Dockerfile.api
+++ b/dedupe/record_linkage_testing/Dockerfile.api
@@ -1,0 +1,13 @@
+ARG VERSION=v1.2.11
+FROM ghcr.io/cdcgov/phdi/record-linkage:${VERSION}
+
+RUN apt-get update && apt-get install -y curl
+
+# Install OpenTelemetry packages for monitoring the record linkage API
+RUN pip install opentelemetry-distro opentelemetry-exporter-otlp
+
+# Auto instrument the record linkage API
+RUN opentelemetry-bootstrap -a install
+
+# Copy our custom testing code into the container
+COPY src /code

--- a/dedupe/record_linkage_testing/Dockerfile.runner
+++ b/dedupe/record_linkage_testing/Dockerfile.runner
@@ -1,0 +1,15 @@
+FROM openjdk:23-slim
+
+ARG SYNTHEA_VERSION=v3.2.0
+ENV SYNTHEA_VERSION=${SYNTHEA_VERSION}
+
+RUN mkdir /code
+WORKDIR /code
+
+RUN apt-get update && apt-get install -y curl uuid-runtime
+
+# Download the Synthea JAR file that we'll use to generate synthetic patient data
+RUN curl https://github.com/synthetichealth/synthea/releases/download/${SYNTHEA_VERSION}/synthea-with-dependencies.jar
+
+# Copy our custom testing code into the container
+COPY scripts /code/scripts

--- a/dedupe/record_linkage_testing/Dockerfile.runner
+++ b/dedupe/record_linkage_testing/Dockerfile.runner
@@ -9,7 +9,7 @@ WORKDIR /code
 RUN apt-get update && apt-get install -y curl uuid-runtime
 
 # Download the Synthea JAR file that we'll use to generate synthetic patient data
-RUN curl https://github.com/synthetichealth/synthea/releases/download/${SYNTHEA_VERSION}/synthea-with-dependencies.jar
+RUN curl -L https://github.com/synthetichealth/synthea/releases/download/${SYNTHEA_VERSION}/synthea-with-dependencies.jar -o synthea.jar
 
 # Copy our custom testing code into the container
 COPY scripts /code/scripts

--- a/dedupe/record_linkage_testing/README.md
+++ b/dedupe/record_linkage_testing/README.md
@@ -6,15 +6,15 @@ This repository contains a performance testing project aimed at evaluating the s
 
 Before getting started, ensure you have the following installed:
 
-- Docker
-- Docker Compose
+- [Docker](https://docs.docker.com/engine/install/)
+- [Docker Compose](https://docs.docker.com/compose/install/)
 
 ## Setup
 
 1. Build the Docker images and start the environment:
 
     ```bash
-    docker-compose up --build -d
+    docker compose up --build -d
     ```
 
     This command will build the necessary Docker images and start the environment in detached mode.
@@ -38,5 +38,5 @@ By default, the OpenTelemetry collector is configured to export telemetry data t
 After you've finished running performance tests and analyzing the results, you can stop and remove the Docker containers by running:
 
 ```bash
-docker-compose down
+docker compose down
 ```

--- a/dedupe/record_linkage_testing/README.md
+++ b/dedupe/record_linkage_testing/README.md
@@ -1,0 +1,42 @@
+# Record Linkage Performance Testing
+
+This repository contains a performance testing project aimed at evaluating the scalability and responsiveness of the [record-linkage](https://github.com/CDCgov/phdi/tree/main/containers/record-linkage) API using [OpenTelemetry](https://opentelemetry.io/) for instrumentation. By utilizing Docker Compose, it provides an easy-to-use environment setup for running performance tests against the target API.
+
+## Prerequisites
+
+Before getting started, ensure you have the following installed:
+
+- Docker
+- Docker Compose
+
+## Setup
+
+1. Build the Docker images and start the environment:
+
+    ```bash
+    docker-compose up --build -d
+    ```
+
+    This command will build the necessary Docker images and start the environment in detached mode.
+
+2. Once the environment is up and running, you can verify that it worked by checking Jaeger at [http://localhost:16686](http://localhost:16686).
+
+3. Run a "Find Traces" query in the Jaeger UI and verify that at least 1 "record-linkage-api: POST /link-record" trace is present.
+
+## Running Performance Tests
+
+More to come...
+
+## Monitoring with OpenTelemetry
+
+The API is instrumented with OpenTelemetry for monitoring and tracing purposes. You can explore the collected metrics and traces using your preferred observability platform compatible with OpenTelemetry, such as Jaeger or Prometheus.
+
+By default, the OpenTelemetry collector is configured to export telemetry data to the local instance of Jaeger, which can be accessed at [http://localhost:16686](http://localhost:16686).
+
+## Cleanup
+
+After you've finished running performance tests and analyzing the results, you can stop and remove the Docker containers by running:
+
+```bash
+docker-compose down
+```

--- a/dedupe/record_linkage_testing/compose.yml
+++ b/dedupe/record_linkage_testing/compose.yml
@@ -1,0 +1,64 @@
+version: "3.8"
+
+services:
+  runner:
+    # The orchestration container of the environment that is used to initialize
+    # run the tests. This container will eventually use Synthea to generate
+    # syntehtic data, transform it into FHIR payloads acceptable by the linkage
+    # API and then run the tests.
+    build:
+      context: .
+      dockerfile: Dockerfile.runner
+    command: ["bash", "scripts/test.sh"]
+    depends_on:
+      api:
+        condition: service_healthy
+
+  api:
+    # The phdi record linkage API that we are testing. We are using a custom Dockerfile
+    # that extends from the phdi container so we can inject OpenTelemetry instrumentation
+    # for tracing.
+    build:
+      context: .
+      dockerfile: Dockerfile.api
+    ports:
+        - "8080:8080"
+    environment:
+      - MPI_DB_TYPE=postgres
+      - MPI_DBNAME=postgres
+      - MPI_HOST=db
+      - MPI_PORT=5432
+      - MPI_USER=postgres
+      - MPI_PASSWORD=pw
+      - MPI_PATIENT_TABLE=patient
+      - MPI_PERSON_TABLE=person
+      - OTEL_TRACES_EXPORTER=otlp
+      - OTEL_EXPORTER_OTLP_ENDPOINT=http://jaeger:4317
+    command: ["opentelemetry-instrument", "--service_name", "record-linkage-api",
+      "uvicorn", "main:app", "--host=0.0.0.0", "--port=8080", "--log-config=app/log_config.yml"]
+    depends_on:
+      - db
+      - jaeger
+    healthcheck:
+      test: ["CMD-SHELL", "curl -sS http://localhost:8080 | grep '\"mpi_connection_status\":\"OK\"' || exit 1"]
+      interval: 5s
+      retries: 5
+
+  db:
+    # The PostgreSQL database that is used to store the patient and person data.
+    image: "postgres:13-alpine"
+    environment:
+      - POSTGRES_PASSWORD=pw
+    ports:
+        - "5432:5432"
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready"]
+
+  jaeger:
+    # The Jaeger all-in-one container that is used to collect, store and visualize
+    # the traces of the service(s).
+    image: "jaegertracing/all-in-one:latest"
+    ports:
+      - "16686:16686"
+    healthcheck:
+      test: ["CMD", "curl", "-f", "http://localhost:16686/"]

--- a/dedupe/record_linkage_testing/scripts/test.sh
+++ b/dedupe/record_linkage_testing/scripts/test.sh
@@ -1,0 +1,68 @@
+#!/bin/bash
+# test.sh: Script to execute the performance tests
+#
+# Usage: test.sh
+
+set -e
+
+cd "$(dirname "$0")/.."
+
+# This is a simple FHIR example to show the environment is working, this will
+# be removed in the future and replaced with a set of scripts that generate data.
+EXAMPLE_FHIR=$(cat << EOF
+{
+    "bundle": {
+        "resourceType": "Bundle",
+        "identifier": {
+            "value": "a very contrived FHIR bundle"
+        },
+        "entry": [
+            {
+                "resource": {
+                    "resourceType": "Patient",
+                    "id": "`uuidgen`",
+                    "identifier": [
+                        {
+                            "value": "0987654321",
+                            "type": {
+                                "coding": [
+                                    {
+                                        "code": "MR",
+                                        "system": "http://terminology.hl7.org/CodeSystem/v2-0203",
+                                        "display": "Medical record number"
+                                    }
+                                ]
+                            }
+                        }
+                    ],
+                    "name": [
+                        {
+                            "family": "Kent",
+                            "given": [
+                                "Clark",
+                                "Superman"
+                            ]
+                        }
+                    ],
+                    "birthDate": "1950-08-04",
+                    "gender": "male",
+                    "address": [
+                        {
+                            "line": [
+                                "some street"
+                            ],
+                            "city": "Topeka",
+                            "state": "Kansas",
+                            "postalCode": "11111",
+                            "use": "home"
+                        }
+                    ]
+                }
+            }
+        ]
+    }
+}
+EOF
+)
+
+curl -X POST http://api:8080/link-record -d "${EXAMPLE_FHIR}" --header "Content-Type: application/json"

--- a/dedupe/record_linkage_testing/src/main.py
+++ b/dedupe/record_linkage_testing/src/main.py
@@ -1,0 +1,41 @@
+"""
+main.py: Main module for performace testing the record linkage API.
+
+This module overrides the default phdi app.main module, so we can monkey patch the
+existing phdi.linkage code with opentelemetry traces.
+
+Usage:
+    uvicorn main:app ...
+"""
+import logging
+import inspect
+
+# Load the original app.main module early so logging and other service values
+# are properly initialized, before we monkey patch the module.
+from app.main import app
+from phdi.linkage import link
+
+from opentelemetry import trace
+
+LOGGER = logging.getLogger(__name__)
+TRACER = trace.get_tracer(__name__)
+
+def instrument_function(func):
+    """
+    Decorator to instrument a function with opentelemetry traces.
+    """
+    def wrapper(*args, **kwargs):
+        with TRACER.start_as_current_span(func.__name__):
+            return func(*args, **kwargs)
+    return wrapper
+
+def instrument_module(module):
+    """
+    Instrument all functions in a module with opentelemetry traces.
+    """
+    for name, obj in inspect.getmembers(module):
+        if inspect.isfunction(obj):
+            setattr(module, name, instrument_function(obj))
+
+LOGGER.warning("Monkey patching %s functions with opentelemetry traces", link.__name__)
+instrument_module(link)

--- a/dedupe/record_linkage_testing/src/main.py
+++ b/dedupe/record_linkage_testing/src/main.py
@@ -11,7 +11,7 @@ import logging
 import inspect
 
 # Load the original app.main module early so logging and other service values
-# are properly initialized, before we monkey patch the module.
+# are properly initialized, before we monkey patch the modules.
 from app.main import app
 from phdi.linkage import link
 
@@ -37,5 +37,5 @@ def instrument_module(module):
         if inspect.isfunction(obj):
             setattr(module, name, instrument_function(obj))
 
-LOGGER.warning("Monkey patching %s functions with opentelemetry traces", link.__name__)
+LOGGER.info("Monkey patching %s functions with opentelemetry traces", link.__name__)
 instrument_module(link)


### PR DESCRIPTION
# PULL REQUEST

## Summary
Add a `compose.yml` file and its dependencies to get a record linkage performance testing environment setup.

## Related Issue
Fixes #9 

## Additional Information
This PR attempts to achieve the following:
- initialize a docker compose environment with the 4 services necessary for running performance tests
- updates .gitignore with some standard rules for python projects
- monkey patches the linkage API container with OpenTelemetry instrumentation
- sets up a test runner container with the Synthea binary
- after initialization, runs a simple `test.sh` script to verify that the API is working and otel events are being gathered