### PR TITLE
[IDWA-28] Fix cron job time to once a day, during weekdays - closing issues

### DIFF
--- a/.github/workflows/issues-close-project-done.yaml
+++ b/.github/workflows/issues-close-project-done.yaml
@@ -1,8 +1,8 @@
 name: Project Issue State Sync
 on:
   schedule:
-    # Runs on minute 0 every 2 hours
-    - cron: 0 0-23/2 * * *
+    # Once at the end of every week day
+    - cron: 0 0 * * 1-5
   workflow_dispatch:
   # Manual trigger
 jobs:


### PR DESCRIPTION
# Pull Request

## Description
Changing the cron job time so the issue closing action runs less daily.

## Related Issues
Currently, the action runs every 2 hours. That is not needed.

## Additional Notes

## Checklist
Please review and complete the following checklist before submitting your pull request:

- [x] I have ensured that the pull request is of a manageable size, allowing it to be reviewed within a single session.
- [x] I have reviewed my changes to ensure they are clear, concise, and well-documented.
- [x] I have updated the documentation, if applicable.
- [x] I have added or updated test cases to cover my changes, if applicable.
- [x] I have minimized the number of reviewers to include only those essential for the review.
- [x] I have notified teammates in the review thread to build awareness.

## Checklist for Reviewers
Please review and complete the following checklist during the review process:

- [ ] The code follows best practices and conventions.
- [ ] The changes implement the desired functionality or fix the reported issue.
- [ ] The tests cover the new changes and pass successfully.
- [ ] Any potential edge cases or error scenarios have been considered.
