### PR TITLE
Minor Cleanup of TemplateIndex

### DIFF
--- a/OCR/frontend/e2e/App.spec.ts
+++ b/OCR/frontend/e2e/App.spec.ts
@@ -25,28 +25,28 @@ test.describe('when templates exist', async () => {
                     lab: "Quest",
                     createdBy: "J.Smith",
                     status: "Completed",
-                    lastUpdated: new Date(Date.parse("2025-03-24 12:00:00:00 GMT-0500"))
+                    lastUpdated: new Date(Date.parse("2025-03-24T12:00:00.000-05:00"))
                 },
                 {
                     name: "LBTIRadar",
                     lab: "Radar",
                     createdBy: "C.Alex",
                     status: "Completed",
-                    lastUpdated: new Date(Date.parse("2025-05-30 12:00:00:00 GMT-0500"))
+                    lastUpdated: new Date(Date.parse("2025-05-30T12:00:00.000-05:00"))
                 },
                 {
                     name: "COVIDBaylor1",
                     lab: "Emory",
                     createdBy: "A.Bryant",
                     status: "Completed",
-                    lastUpdated: new Date(Date.parse("2025-06-21 12:00:00:00 GMT-0500"))
+                    lastUpdated: new Date(Date.parse("2025-06-21T12:00:00.000-05:00"))
                 },
                 {
                     name: "COVIDEMory",
                     lab: "Baylor",
                     createdBy: "D.Smith",
                     status: "Completed",
-                    lastUpdated: new Date(Date.parse("2024-06-21 12:00:00:00 GMT-0500"))
+                    lastUpdated: new Date(Date.parse("2024-06-21T12:00:00.000-05:00"))
                 },
             ];
             localStorage.setItem('templates', JSON.stringify(templates))

--- a/OCR/frontend/e2e/App.spec.ts
+++ b/OCR/frontend/e2e/App.spec.ts
@@ -1,7 +1,4 @@
 import { test, expect } from '@playwright/test';
-import {Simulate} from "react-dom/test-utils";
-import click = Simulate.click;
-import {describe} from "vitest";
 
 test('has STLT Name', async ({ page }) => {
     await page.goto('/');
@@ -28,28 +25,28 @@ test.describe('when templates exist', async () => {
                     lab: "Quest",
                     createdBy: "J.Smith",
                     status: "Completed",
-                    lastUpdated: new Date(Date.parse("2025-03-24"))
+                    lastUpdated: new Date(Date.parse("2025-03-24 12:00:00:00 GMT-0500"))
                 },
                 {
                     name: "LBTIRadar",
                     lab: "Radar",
                     createdBy: "C.Alex",
                     status: "Completed",
-                    lastUpdated: new Date(Date.parse("2025-05-30"))
+                    lastUpdated: new Date(Date.parse("2025-05-30 12:00:00:00 GMT-0500"))
                 },
                 {
                     name: "COVIDBaylor1",
                     lab: "Emory",
                     createdBy: "A.Bryant",
                     status: "Completed",
-                    lastUpdated: new Date(Date.parse("2025-06-21"))
+                    lastUpdated: new Date(Date.parse("2025-06-21 12:00:00:00 GMT-0500"))
                 },
                 {
                     name: "COVIDEMory",
                     lab: "Baylor",
                     createdBy: "D.Smith",
                     status: "Completed",
-                    lastUpdated: new Date(Date.parse("2024-06-21"))
+                    lastUpdated: new Date(Date.parse("2024-06-21 12:00:00:00 GMT-0500"))
                 },
             ];
             localStorage.setItem('templates', JSON.stringify(templates))

--- a/OCR/frontend/playwright.config.ts
+++ b/OCR/frontend/playwright.config.ts
@@ -29,7 +29,12 @@ export default defineConfig({
 
     /* Collect trace when retrying the failed test. See https://playwright.dev/docs/trace-viewer */
     trace: 'on-first-retry',
+    // Emulates the user locale.
+    locale: 'en-US',
+    // Emulates the user timezone.
+    timezoneId: 'America/Chicago',
   },
+
 
   /* Configure projects for major browsers */
   projects: [

--- a/OCR/frontend/src/components/SortableTable/SortableTable.tsx
+++ b/OCR/frontend/src/components/SortableTable/SortableTable.tsx
@@ -26,12 +26,11 @@ export const SortableTable: FC<SortableTableProps> = ({
                                                           sortableBy,
                                                           defaultSort,
                                                           defaultDescending = false,
-                                                          columns, formatters = {},
+                                                          columns = Object.keys(data[0]),
+                                                          formatters = {},
                                                           columnNames = {},
                                                       }: SortableTableProps) => {
-    if (!columns) {
-        columns = Object.keys(data[0])
-    }
+
     const [sortBy, setSortBy] = useState(defaultSort || columns?.[0])
     const [isDescending, setIsDescending] = useState(defaultDescending)
 
@@ -54,7 +53,6 @@ export const SortableTable: FC<SortableTableProps> = ({
 
 
     return (
-        <>
             <Table fullWidth striped>
                 <thead>
                 <tr>
@@ -75,7 +73,6 @@ export const SortableTable: FC<SortableTableProps> = ({
                 })}
                 </tbody>
             </Table>
-        </>
     )
 }
 
@@ -95,7 +92,7 @@ const SortableTableHeader: FC<SortableTableHeaderProps> = ({
                                                            }: SortableTableHeaderProps) => {
 
     const isSortedBy = sortBy === column
-    return <>
+    return (
         <th onClick={() => onClick(column)}>
             <div className="display-flex flex-row">
                 <div>{name}</div>
@@ -103,7 +100,7 @@ const SortableTableHeader: FC<SortableTableHeaderProps> = ({
             {isSortedBy ? <SortOrderIcon isDescending={isDescending}/> : <SortIcon/>}
             </div>
         </th>
-    </>
+    )
 }
 
 interface SortIconProps {
@@ -111,14 +108,12 @@ interface SortIconProps {
 }
 
 const SortOrderIcon: FC<SortIconProps> = ({isDescending = false}) => {
-    return <>
+    return (
         <img className={`margin-left-1 height-2 ${isDescending ? '' : 'sort-arrow-up'}`} src={SortArrow}
              alt={`Sorting ${isDescending ? 'descending' : 'ascending'}`}/>
-    </>
+    )
 }
 
 const SortIcon: FC = () => {
-    return <>
-        <img className={`margin-left-1 height-2 `} src={SortableIcon} alt="Sort by"/>
-    </>
+    return <img className={`margin-left-1 height-2 `} src={SortableIcon} alt="Sort by"/>
 }

--- a/OCR/frontend/src/components/TemplatesIndex/TemplatesIndex.tsx
+++ b/OCR/frontend/src/components/TemplatesIndex/TemplatesIndex.tsx
@@ -62,28 +62,28 @@ export const TemplatesIndex: FC<TemplateIndexProps> = ({}) => {
             lab: "Quest",
             createdBy: "J.Smith",
             status: "Completed",
-            lastUpdated: new Date(Date.parse("2025-03-24 12:00:00:00 GMT-0500"))
+            lastUpdated: new Date(Date.parse("2025-03-24T12:00:00.000-05:00"))
         },
         {
             name: "LBTIRadar",
             lab: "Radar",
             createdBy: "C.Alex",
             status: "Completed",
-            lastUpdated: new Date(Date.parse("2025-05-30 12:00:00:00 GMT-0500"))
+            lastUpdated: new Date(Date.parse("2025-05-30T12:00:00.000-05:00"))
         },
         {
             name: "COVIDBaylor1",
             lab: "Emory",
             createdBy: "A.Bryant",
             status: "Completed",
-            lastUpdated: new Date(Date.parse("2025-06-21 12:00:00:00 GMT-0500"))
+            lastUpdated: new Date(Date.parse("2025-06-21T12:00:00.000-05:00"))
         },
         {
             name: "COVIDEMory",
             lab: "Baylor",
             createdBy: "D.Smith",
             status: "Completed",
-            lastUpdated: new Date(Date.parse("2024-06-21 12:00:00:00 GMT-0500"))
+            lastUpdated: new Date(Date.parse("2024-06-21T12:00:00.000-05:00"))
         },
     ];
 

--- a/OCR/frontend/src/components/TemplatesIndex/TemplatesIndex.tsx
+++ b/OCR/frontend/src/components/TemplatesIndex/TemplatesIndex.tsx
@@ -62,28 +62,28 @@ export const TemplatesIndex: FC<TemplateIndexProps> = ({}) => {
             lab: "Quest",
             createdBy: "J.Smith",
             status: "Completed",
-            lastUpdated: new Date(Date.parse("2025-03-24"))
+            lastUpdated: new Date(Date.parse("2025-03-24 12:00:00:00 GMT-0500"))
         },
         {
             name: "LBTIRadar",
             lab: "Radar",
             createdBy: "C.Alex",
             status: "Completed",
-            lastUpdated: new Date(Date.parse("2025-05-30"))
+            lastUpdated: new Date(Date.parse("2025-05-30 12:00:00:00 GMT-0500"))
         },
         {
             name: "COVIDBaylor1",
             lab: "Emory",
             createdBy: "A.Bryant",
             status: "Completed",
-            lastUpdated: new Date(Date.parse("2025-06-21"))
+            lastUpdated: new Date(Date.parse("2025-06-21 12:00:00:00 GMT-0500"))
         },
         {
             name: "COVIDEMory",
             lab: "Baylor",
             createdBy: "D.Smith",
             status: "Completed",
-            lastUpdated: new Date(Date.parse("2024-06-21"))
+            lastUpdated: new Date(Date.parse("2024-06-21 12:00:00:00 GMT-0500"))
         },
     ];
 


### PR DESCRIPTION
Fixes some comments in #230. 

- Remove React.Fragments that weren't needed
- Use JS default arguments in place of if statement in function body
- Remove unused imports added incorrectly by editor trying to be helpful
- Fixed timezone bug in E2E tests


