### PR TITLE
Automatically align images before OCR

### DIFF
--- a/frontend/api/api.ts
+++ b/frontend/api/api.ts
@@ -2,7 +2,7 @@ import { ImageToTextArgs, ImageToTextResponse, AlignImageArgs, AlignImageRespons
 
 const apiUrl = import.meta.env.VITE_API_URL || "http://localhost:8000/"
 
-export const AlignImage = async (args: AlignImageArgs): Promise<AlignImageResponse | null> => {
+export const AlignImage = async (args: AlignImageArgs): Promise<AlignImageResponse> => {
     const { sourceImage, templateImage } = args;
     const form = new URLSearchParams({
         source_image: sourceImage,
@@ -21,15 +21,16 @@ export const AlignImage = async (args: AlignImageArgs): Promise<AlignImageRespon
           return await response.json() as AlignImageResponse;
     } catch (error) {
         console.error(error);
-        return null;
+        return {result: sourceImage};
     }
 }
 
 export const ImageToText = async (args: ImageToTextArgs): Promise<ImageToTextResponse | null> => {
 
     const { sourceImage, templateImage, fieldNames } = args;
+    const aligned_result = await AlignImage({sourceImage, templateImage});
     const form = new URLSearchParams({
-        source_image: sourceImage,
+        source_image: aligned_result["result"],
         segmentation_template: templateImage,
         labels: JSON.stringify(fieldNames),
       });

--- a/frontend/api/types/types.ts
+++ b/frontend/api/types/types.ts
@@ -13,7 +13,7 @@ export type ImageToTextResponse = {
 };
 
 export type AlignImageResponse = {
-    [key: string]: [string, number];
+    [key: string]: string;
 };
 
 export interface ResultItem {


### PR DESCRIPTION
## Description
Automatically align images that are provided to the OCR API.

Some type changes were needed and I've made the image alignment function call to ensure that it shouldn't return `null`, instead, it will return the original image to be aligned and log an error message to the console.

## Screenshots (if applicable)

## Related Issues
https://github.com/CDCgov/ReportVision/issues/383

## Checklist
- [x] The title of this PR is descriptive and concise.
- [x] My changes follow the style guidelines of this project.
- [ ] I have added or updated test cases to cover my changes.
- [x] I've let the team know about this PR by linking it in the review channel


