### PR TITLE
Swap over to tesseract for OCR requests

### DIFF
--- a/OCR/ocr/api.py
+++ b/OCR/ocr/api.py
@@ -10,7 +10,7 @@ import asyncio
 from fastapi import FastAPI, UploadFile, Form, HTTPException
 from fastapi.middleware.cors import CORSMiddleware
 
-from ocr.services.image_ocr import ImageOCR
+from ocr.services.tesseract_ocr import TesseractOCR
 from ocr.services.alignment import ImageAligner
 from ocr.services.image_segmenter import ImageSegmenter, segment_by_color_bounding_box
 
@@ -31,7 +31,7 @@ app.add_middleware(
 segmenter = ImageSegmenter(
     segmentation_function=segment_by_color_bounding_box,
 )
-ocr = ImageOCR()
+ocr = TesseractOCR()
 
 
 def data_uri_to_image(data_uri: str):


### PR DESCRIPTION
## Description

Switches the OCR backend to use tesseract instead of tr-ocr. 

## Screenshots (if applicable)

## Related Issues
https://github.com/CDCgov/ReportVision/issues/414

## Checklist
- [x] The title of this PR is descriptive and concise.
- [x] My changes follow the style guidelines of this project.
- [ ] I have added or updated test cases to cover my changes.
- [x] I've let the team know about this PR by linking it in the review channel


