### PR TITLE
Fix frontend `node_modules`

### DIFF
--- a/dev-env.yaml
+++ b/dev-env.yaml
@@ -18,6 +18,7 @@ services:
       - "8080:8080"
     volumes:
       - ./frontend:/app
+      - /app/node_modules
     depends_on:
       - api
       - ocr


### PR DESCRIPTION
## Description

Adds an anonymous `node_modules` volume to the frontend docker container. This ensures that the host's `node_modules` are not copied over during container instantiation.

## Related Issues

https://github.com/CDCgov/ReportVision/issues/465

## Checklist
- [x] The title of this PR is descriptive and concise.
- [x] My changes follow the style guidelines of this project.
- [ ] I have added or updated test cases to cover my changes.
- [x] I've let the team know about this PR by linking it in the review channel


